### PR TITLE
Top podcasts always takes up the same amounth of space now

### DIFF
--- a/src/Assets/Styles/Components/Podcast/listablepodcast.scss
+++ b/src/Assets/Styles/Components/Podcast/listablepodcast.scss
@@ -1,5 +1,6 @@
 .listable-podcast {
   padding: 1em;
+  width: min-content;
 
   img {
     min-width: 250px;
@@ -10,6 +11,7 @@
     flex-direction: column;
     font-size: 0.9em;
     padding-top: 0.5em;
+    word-break: break-word;
 
     span {
       padding-top: 0.5em;

--- a/src/Components/Podcasts/ListablePodcast.tsx
+++ b/src/Components/Podcasts/ListablePodcast.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Podcast } from '../../Models/Podcast';
 import { getDatefromMilisecond } from '../../Helpers/Time';
+import { setMaxLength } from '../../Helpers/Utils';
 
 interface Props {
   data: Podcast;
@@ -13,7 +14,7 @@ const ListablePodcast = ({ data }: Props): JSX.Element => (
       <figure>
         <img src={typeof data.image === 'string' ? data.image : ''} alt="podcastlogo" className="podcast-logo" />
         <figcaption>
-          {data.title}
+          {setMaxLength(typeof data.title === 'string' ? data.title : '', 65)}
           <span>
             {getDatefromMilisecond(typeof data.lastest_pub_date_ms === 'number' ? data.lastest_pub_date_ms : 0)}
           </span>


### PR DESCRIPTION
* Add with top listable podcast
* Add word-break: break-word to figcaption for listable episode
* Add a max length of 65 characters for displayed podcast titels

Issue #52