### PR TITLE
Enable rendering of descriptions/titles containing markup

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "babel-loader": "8.0.4",
     "downloadjs": "^1.4.7",
     "immutable": "^4.0.0-rc.12",
+    "interweave": "^11.0.0",
     "jsonwebtoken": "^8.4.0",
     "prop-types": "^15.6.2",
     "react": "^16.8.1",

--- a/src/Assets/Styles/Components/Episodes/episode.scss
+++ b/src/Assets/Styles/Components/Episodes/episode.scss
@@ -4,7 +4,7 @@
   justify-content: center;
   align-items: center;
 
-  .episode-title {
+  h3 {
     width: 80%;
     font-size: 3em;
     text-align: center;
@@ -18,6 +18,15 @@
       font-size: 0.9em;
       line-height: 1.3em;
       word-spacing: 0.15em;
+    }
+
+    a {
+      text-decoration: underline;
+    }
+
+    a:hover,
+    a:active {
+      color: rgba(159, 205, 244, 0.75);
     }
   }
 
@@ -87,7 +96,7 @@
 
 @media only screen and (max-width: 640px) {
   .episode {
-    .episode-title {
+    h3 {
       font-size: 2em;
       width: 90%;
     }

--- a/src/Assets/Styles/Components/Podcast/podcast.scss
+++ b/src/Assets/Styles/Components/Podcast/podcast.scss
@@ -13,11 +13,17 @@
 
   .podcast-description {
     width: 60%;
+    font-size: 0.9em;
+    line-height: 1.3em;
+    word-spacing: 0.15em;
 
-    p {
-      font-size: 0.9em;
-      line-height: 1.3em;
-      word-spacing: 0.15em;
+    a {
+      text-decoration: underline;
+    }
+
+    a:hover,
+    a:active {
+      color: rgba(159, 205, 244, 0.75);
     }
   }
 

--- a/src/Assets/Styles/Components/Search/listable-episode.scss
+++ b/src/Assets/Styles/Components/Search/listable-episode.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: space-evenly;
+  justify-content: space-between;
   width: 295px;
   height: 270px;
   background-color: rgba(159, 205, 244, 0.3);
@@ -21,8 +21,6 @@
     padding: 0.25em 0;
   }
 
-  .listable-episode-description,
-  .listable-episode-controls,
   .listable-episode-info {
     figure {
       width: 50px;
@@ -52,13 +50,30 @@
     }
   }
 
-  div:last-child {
+  .listable-episode-controls,
+  .listable-episode-description {
     justify-content: space-between;
     align-items: center;
     margin-bottom: -0.5em;
   }
 
-  .listable-episode-title {
+  .listable-episode-description {
+    margin-left: 0.5em;
+    margin-top: 0.3em;
+    font-size: 14px;
+    word-break: break-word;
+
+    a {
+      text-decoration: underline;
+    }
+
+    a:hover,
+    a:active {
+      color: rgba(159, 205, 244, 0.75);
+    }
+  }
+
+  h3 {
     padding: 0.5em 0;
   }
 }

--- a/src/Assets/Styles/Components/Search/listable-podcast-searchresult.scss
+++ b/src/Assets/Styles/Components/Search/listable-podcast-searchresult.scss
@@ -10,7 +10,9 @@
   margin: 0.5em 0;
   padding: 0.5em;
 
-  div {
+  .listable-podcast-description,
+  .listable-podcast-controls,
+  .listable-podcast-img {
     display: inline-flex;
     flex-direction: row;
     width: 100%;
@@ -34,7 +36,8 @@
     }
   }
 
-  div:last-child {
+  .listable-podcast-description,
+  .listable-podcast-controls {
     justify-content: space-between;
     align-items: center;
     padding-top: 1em;
@@ -44,7 +47,8 @@
     padding: 0.5em 0;
   }
 
-  p {
+  p,
+  .listable-podcast-description {
     margin-top: 0.3em;
     margin-left: 0.5em;
     font-size: 14px;
@@ -53,5 +57,16 @@
     align-items: flex-start;
     flex-direction: column;
     word-break: break-word;
+  }
+
+  .listable-podcast-description {
+    a {
+      text-decoration: underline;
+    }
+
+    a:active,
+    a:hover {
+      color: rgba(159, 205, 244, 0.75);
+    }
   }
 }

--- a/src/Components/Common/ImageLink.tsx
+++ b/src/Components/Common/ImageLink.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { Markup } from 'interweave';
 
 interface Props {
   imageSrc: string;
@@ -15,14 +16,14 @@ const ImageLink = ({
     <Link to={linkTo}>
       <figure>
         <img src={imageSrc} alt={imageAlt} />
-        <figcaption>{caption}</figcaption>
+        <Markup content={caption} tagName="figcaption" />
       </figure>
     </Link>
   )
     : (
       <figure>
         <img src={imageSrc} alt={imageAlt} />
-        <figcaption>{caption}</figcaption>
+        <Markup content={caption} tagName="figcaption" />
       </figure>
     )
 );

--- a/src/Components/Episodes/Episode.tsx
+++ b/src/Components/Episodes/Episode.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import { Markup } from 'interweave';
 import { Episode } from '../../Models/Episode';
 import PlayButton from '../../Containers/Common/PlayButton';
 import MoreOptionsButton from '../../Containers/Common/MoreOptions/MoreOptionsButton';
@@ -55,7 +56,7 @@ function EpisodeComponent({
 
   return !isFetching && typeof episode.id === 'string' ? (
     <div className="episode">
-      <h3 className="episode-title">{ title }</h3>
+      <Markup content={title} tagName="h3" />
       <div className="episode-img">
         <figure>
           <img src={typeof episode.image === 'string' ? episode.image : ''} alt="podcastlogo" />
@@ -71,9 +72,7 @@ function EpisodeComponent({
         <InfoBox text={epiosdeLength} />
       </div>
       <div className="episode-description">
-        <p>
-          {description}
-        </p>
+        <Markup content={description} />
       </div>
       <div className="episode-controls">
         <DownloadButton episode={episode} />

--- a/src/Components/Feed/Event.tsx
+++ b/src/Components/Feed/Event.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Markup } from 'interweave';
 import { Event } from '../../Models/Event';
 import ArrowRight from '../../Assets/Icons/arrow-right-fat.svg';
 import ImageLink from '../Common/ImageLink';
@@ -151,7 +152,7 @@ const EventComponent = ({ data }: Props): JSX.Element | null => {
       );
       break;
     case 'newEpisode':
-      message = `${agentName} relesed a new episode — ${objectName}`;
+      message = `${agentName} relesed a new episode: ${objectName}`;
       eventImages = (
         <div className="event-images">
           <ImageLink
@@ -179,9 +180,7 @@ const EventComponent = ({ data }: Props): JSX.Element | null => {
     <div className="event">
       {eventImages}
       <div className="event-description">
-        <p>
-          {message}
-        </p>
+        <Markup content={message} tagName="p" />
       </div>
       <div className="date">
         <InfoBox text={formatedDate} />

--- a/src/Components/Notifications/Notification.tsx
+++ b/src/Components/Notifications/Notification.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { Markup } from 'interweave';
 import { Notification } from '../../Models/Notification';
 import { setMaxLength } from '../../Helpers/Utils';
 
@@ -49,7 +50,7 @@ function NotificationComponent({
       thumbnail = image || '';
       break;
     case 'newEpisode': {
-      message = `${agentName} has a new episode — ${objectName}`;
+      message = `${agentName} has a new episode: ${objectName}`;
       linkTo = `/episodes/${object._id}`;
       break;
     }
@@ -84,9 +85,7 @@ function NotificationComponent({
               alt={objectName.length > 0 ? objectName : agentName}
             />
           </figure>
-          <p>
-            {message}
-          </p>
+          <Markup content={message} tagName="p" />
         </div>
       </Link>
     </div>

--- a/src/Components/Podcasts/ListablePodcast.tsx
+++ b/src/Components/Podcasts/ListablePodcast.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { Markup } from 'interweave';
 import { Podcast } from '../../Models/Podcast';
 import { getDatefromMilisecond } from '../../Helpers/Time';
 import { setMaxLength } from '../../Helpers/Utils';
@@ -14,7 +15,7 @@ const ListablePodcast = ({ data }: Props): JSX.Element => (
       <figure>
         <img src={typeof data.image === 'string' ? data.image : ''} alt="podcastlogo" className="podcast-logo" />
         <figcaption>
-          {setMaxLength(typeof data.title === 'string' ? data.title : '', 65)}
+          <Markup content={setMaxLength(typeof data.title === 'string' ? data.title : '', 65)} tagName="span" />
           <span>
             {getDatefromMilisecond(typeof data.lastest_pub_date_ms === 'number' ? data.lastest_pub_date_ms : 0)}
           </span>

--- a/src/Components/Podcasts/Podcast.tsx
+++ b/src/Components/Podcasts/Podcast.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { Markup } from 'interweave';
 import { Podcast } from '../../Models/Podcast';
 import Loader from '../Layout/Loader';
 import SubscribeButton from '../../Containers/Common/SubscribeButton';
@@ -63,9 +64,7 @@ function PodcastComponent({
         </figure>
       </div>
       <div className="podcast-description">
-        <p>
-          {description}
-        </p>
+        <Markup content={description} />
       </div>
       <div className="podcast-controls">
         <RatingComponent rating={typeof rating === 'number' ? rating : 0} />

--- a/src/Components/Podcasts/PodcastEpisode.tsx
+++ b/src/Components/Podcasts/PodcastEpisode.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { Markup } from 'interweave';
 import { getDatefromMilisecond } from '../../Helpers/Time';
 import DownloadButton from '../../Containers/Common/DownloadButton';
 import { Episode } from '../../Models/Episode';
@@ -7,7 +8,7 @@ import MoreOptionsButton from '../../Containers/Common/MoreOptions/MoreOptionsBu
 import PlayButton from '../../Containers/Common/PlayButton';
 import InfoBox from '../Common/InfoBox';
 import { Rating } from '../../Models/Rating';
-import { getRatingIcon } from '../../Helpers/Utils';
+import { getRatingIcon, setMaxLength } from '../../Helpers/Utils';
 import { useSocket } from '../../Helpers/CustomHooks';
 
 interface Props {
@@ -41,22 +42,20 @@ function PodcastEpisode({
   return (
     <div className="listable-episode">
       <Link to={`/episodes/${episodeId}`}>
-        <h3 className="listable-episode-title">{title.length > 35 ? `${title.substring(0, 31)}...` : title}</h3>
-        <div className="listable-episode-info-boxes">
-          <InfoBox text={episodeReleaseDate} />
-          <InfoBox
-            text={typeof rating === 'number' && rating > 0 ? rating.toFixed(1) : ' - '}
-            iconClass={ratingIcon}
-            icon
-          />
-          <InfoBox text={epiosdeLength} />
-        </div>
-        <div className="listable-episode-description">
-          <p>
-            {description.length > 150 ? `${description.substring(0, 147)}...` : description}
-          </p>
-        </div>
+        <h3 className="listable-episode-title"><Markup content={setMaxLength(title, 35)} /></h3>
       </Link>
+      <div className="listable-episode-info-boxes">
+        <InfoBox text={episodeReleaseDate} />
+        <InfoBox
+          text={typeof rating === 'number' && rating > 0 ? rating.toFixed(1) : ' - '}
+          iconClass={ratingIcon}
+          icon
+        />
+        <InfoBox text={epiosdeLength} />
+      </div>
+      <div className="listable-episode-description">
+        <Markup content={setMaxLength(description, 100)} />
+      </div>
       <div className="listable-episode-controls">
         <DownloadButton episode={data} />
         <PlayButton episode={data} />

--- a/src/Components/Search/ListableEpisode.tsx
+++ b/src/Components/Search/ListableEpisode.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { Markup } from 'interweave';
 import { getDatefromMilisecond, getSecondsFromTimeString } from '../../Helpers/Time';
 import DownloadButton from '../../Containers/Common/DownloadButton';
 import { Episode } from '../../Models/Episode';
@@ -7,8 +8,9 @@ import MoreOptionsButton from '../../Containers/Common/MoreOptions/MoreOptionsBu
 import PlayButton from '../../Containers/Common/PlayButton';
 import InfoBox from '../Common/InfoBox';
 import { Rating } from '../../Models/Rating';
-import { getRatingIcon } from '../../Helpers/Utils';
+import { getRatingIcon, setMaxLength } from '../../Helpers/Utils';
 import { useSocket } from '../../Helpers/CustomHooks';
+import ImageLink from '../Common/ImageLink';
 
 interface Props {
   data: Episode;
@@ -39,31 +41,29 @@ function ListableEpisode({
   return (
     <div className="listable-episode">
       <Link to={`/episodes/${episodeId}`}>
-        <h3 className="listable-episode-title">
-          {episodeTitle.length > 35 ? `${episodeTitle.substring(0, 31)}...` : episodeTitle}
-        </h3>
-        <div className="listable-episode-info">
-          <figure>
-            <img src={typeof data.thumbnail === 'string' ? data.thumbnail : ''} alt="podcastlogo" />
-          </figure>
-          <p>
-            <span>{podcastTitle.length > 30 ? `${podcastTitle.substring(0, 26)}...` : podcastTitle}</span>
-            <span>{`By ${publisher.length > 27 ? `${publisher.substring(0, 23)}...` : publisher}`}</span>
-            <span>
-              {`Relseed: ${typeof data.pub_date_ms === 'number' ? getDatefromMilisecond(data.pub_date_ms) : '—'}`}
-            </span>
-          </p>
-        </div>
-        <div className="listable-episode-info-boxes">
-          <InfoBox text={typeof rating === 'number' ? rating.toFixed(1) : ' - '} iconClass={ratingIcon} icon />
-          <InfoBox text={epiosdeLength} />
-        </div>
-        <div className="listable-episode-description">
-          <p>
-            {description.length > 150 ? `${description.substring(0, 147)}...` : description}
-          </p>
-        </div>
+        <Markup content={setMaxLength(episodeTitle, 35)} tagName="h3" />
       </Link>
+      <div className="listable-episode-info">
+        <ImageLink
+          imageSrc={typeof data.thumbnail === 'string' ? data.thumbnail : ''}
+          imageAlt="podcastlogo"
+          linkTo={`/episodes/${episodeId}`}
+        />
+        <p>
+          <span>{setMaxLength(podcastTitle, 30)}</span>
+          <span>{`By ${setMaxLength(publisher, 27)}`}</span>
+          <span>
+            {`Relseed: ${typeof data.pub_date_ms === 'number' ? getDatefromMilisecond(data.pub_date_ms) : '—'}`}
+          </span>
+        </p>
+      </div>
+      <div className="listable-episode-info-boxes">
+        <InfoBox text={typeof rating === 'number' ? rating.toFixed(1) : ' - '} iconClass={ratingIcon} icon />
+        <InfoBox text={epiosdeLength} />
+      </div>
+      <div className="listable-episode-description">
+        <Markup content={setMaxLength(description, 100)} />
+      </div>
       <div className="listable-episode-controls">
         <DownloadButton episode={data} />
         <PlayButton episode={data} />

--- a/src/Components/Search/ListablePodcast.tsx
+++ b/src/Components/Search/ListablePodcast.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { Markup } from 'interweave';
 import { getDatefromMilisecond } from '../../Helpers/Time';
 import { Podcast } from '../../Models/Podcast';
 import SubscribeButton from '../../Containers/Common/SubscribeButton';
@@ -7,6 +8,8 @@ import RatingComponent from '../Common/Rating';
 import MoreOptionsButton from '../../Containers/Common/MoreOptions/MoreOptionsButton';
 import { Rating } from '../../Models/Rating';
 import { useSocket } from '../../Helpers/CustomHooks';
+import { setMaxLength } from '../../Helpers/Utils';
+import ImageLink from '../Common/ImageLink';
 
 interface Props {
   data: Podcast;
@@ -52,30 +55,30 @@ function ListablePodcast({
 
   return (
     <div className="listable-podcast-searchresult">
-      <Link to={`/podcasts/${typeof data.id === 'string' ? data.id : ''}`}>
-        <h3>{title.length > 35 ? `${title.substring(0, 31)}...` : title}</h3>
-        <div>
-          <figure>
-            <img src={typeof data.thumbnail === 'string' ? data.thumbnail : ''} alt="podcastlogo" />
-          </figure>
-          <p>
-            <span>{`By ${publisher.length > 27 ? `${publisher.substring(0, 23)}...` : publisher}`}</span>
-            <span>
-              {`Last updated ${
-                getDatefromMilisecond(
-                  typeof data.lastest_pub_date_ms === 'number' ? data.lastest_pub_date_ms : 0,
-                )}
-              `}
-            </span>
-          </p>
-        </div>
+      <Link to={`/podcasts/${podcastId}`}>
+        <Markup content={setMaxLength(title, 35)} tagName="h3" />
       </Link>
-      <div>
+      <div className="listable-podcast-img">
+        <ImageLink
+          imageSrc={typeof data.thumbnail === 'string' ? data.thumbnail : ''}
+          imageAlt="podcastlogo"
+          linkTo={`/podcasts/${podcastId}`}
+        />
         <p>
-          {description.length > 150 ? `${description.substring(0, 147)}...` : description}
+          <span>{`By ${setMaxLength(publisher, 27)}`}</span>
+          <span>
+            {`Last updated ${
+              getDatefromMilisecond(
+                typeof data.lastest_pub_date_ms === 'number' ? data.lastest_pub_date_ms : 0,
+              )}
+              `}
+          </span>
         </p>
       </div>
-      <div>
+      <div className="listable-podcast-description">
+        <Markup content={setMaxLength(description, 100)} />
+      </div>
+      <div className="listable-podcast-controls">
         <RatingComponent rating={typeof rating === 'number' ? rating : 0} />
         <SubscribeButton podcast={data} />
         <MoreOptionsButton item={data} />

--- a/src/Helpers/Utils.ts
+++ b/src/Helpers/Utils.ts
@@ -1,9 +1,34 @@
-export function setMaxLength(word: string, maxLength: number): string {
-  if (word.length < maxLength) {
-    return word;
-  }
+function removeHtmlFromString(string: string): string {
+  return string.replace(/<(?:.|\n)*?>/gm, '');
+}
 
-  return `${word.substring(0, maxLength - 4)}...`;
+function getMarkupOffset(text: string, maxLength: number): number {
+  const matchedMarkup = text.match(/<(?:.|\n)*?>/gm);
+  let markupOffset = 0;
+  if (matchedMarkup) {
+    let lastMatchIndex = 0;
+    for (let i = 0; i < matchedMarkup.length; i += 1) {
+      const indexOfMatch = text.indexOf(matchedMarkup[i], lastMatchIndex);
+
+      if (indexOfMatch > maxLength + markupOffset) {
+        break;
+      }
+
+      lastMatchIndex = indexOfMatch;
+      markupOffset += matchedMarkup[i].length;
+    }
+  }
+  return markupOffset;
+}
+
+export function setMaxLength(text: string, maxLength: number): string {
+  const cleanText = removeHtmlFromString(text);
+  if (cleanText.length < maxLength) {
+    return text;
+  }
+  const markupOffset = getMarkupOffset(text, maxLength);
+
+  return `${text.substring(0, maxLength + markupOffset - 4)}...`;
 }
 
 export const getRatingIcon = (rating: number): string => {


### PR DESCRIPTION
* Add interweave package
* use Markup component from interweave to safly render strings containing html markup
* Modify setMaxLength function to kompensate for markup when checking the length of a text string
* minor styling updates
* use ImageLink in ListableEpisode And ListablePodcast

Issue #59